### PR TITLE
tests update, code simplify, remove unused

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -89,4 +89,6 @@ jobs:
         uses: reviewdog/action-golangci-lint@v1
         with:
           github_token: ${{ secrets.github_token }}
+          golangci_lint_flags: "-D errcheck"
+
 

--- a/broker/amqp/broker_test.go
+++ b/broker/amqp/broker_test.go
@@ -24,58 +24,87 @@ var (
 func TestBroker_Init(t *testing.T) {
 	b := &Broker{}
 	ok, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.True(t, ok)
 	assert.NoError(t, err)
 }
 
 func TestBroker_StopNotStarted(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	b.Stop()
 }
 
 func TestBroker_Register(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 }
 
 func TestBroker_Register_Twice(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 	assert.Error(t, b.Register(pipe))
 }
 
 func TestBroker_Consume_Nil_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_Undefined(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	assert.NoError(t, b.Consume(pipe, exec, err))
+	assert.NoError(t, b.Consume(pipe, exec, errf))
 }
 
 func TestBroker_Consume_BadPipeline(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Error(t, b.Register(&jobs.Pipeline{
 		"broker":   "amqp",
 		"name":     "default",
@@ -86,10 +115,18 @@ func TestBroker_Consume_BadPipeline(t *testing.T) {
 
 func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
-	b.Consume(pipe, nil, nil)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Consume(pipe, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -104,22 +141,34 @@ func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 
 func TestBroker_Consume_CantStart(t *testing.T) {
 	b := &Broker{}
-	b.Init(&Config{
+	_, err := b.Init(&Config{
 		Addr: "amqp://guest:guest@localhost:15672/",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.Serve())
 }
 
 func TestBroker_Consume_Serve_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	b.Consume(pipe, exec, err)
+	err = b.Consume(pipe, exec, errf)
+	if err != nil {
+		t.Fatal()
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -134,25 +183,40 @@ func TestBroker_Consume_Serve_Stop(t *testing.T) {
 
 func TestBroker_PushToNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }
 
 func TestBroker_PushToNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -166,13 +230,16 @@ func TestBroker_PushToNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -186,6 +253,6 @@ func TestBroker_StatNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }

--- a/broker/amqp/conn.go
+++ b/broker/amqp/conn.go
@@ -20,7 +20,8 @@ type chanPool struct {
 // manages single channel
 type channel struct {
 	ch       *amqp.Channel
-	consumer string
+	// todo unused
+	//consumer string
 	confirm  chan amqp.Confirmation
 	signal   chan error
 }

--- a/broker/amqp/consume_test.go
+++ b/broker/amqp/consume_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestBroker_Consume_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -50,7 +53,10 @@ func TestBroker_Consume_Job(t *testing.T) {
 
 func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -90,7 +96,11 @@ func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 
 func TestBroker_Consume_Delayed(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -135,7 +145,10 @@ func TestBroker_Consume_Delayed(t *testing.T) {
 
 func TestBroker_Consume_Errored(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -178,7 +191,10 @@ func TestBroker_Consume_Errored(t *testing.T) {
 
 func TestBroker_Consume_Errored_Attempts(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})

--- a/broker/amqp/durability_test.go
+++ b/broker/amqp/durability_test.go
@@ -112,8 +112,14 @@ func TestBroker_Durability_Base(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -167,9 +173,14 @@ func TestBroker_Durability_Consume(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -245,9 +256,14 @@ func TestBroker_Durability_Consume_LongTimeout(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -334,9 +350,14 @@ func TestBroker_Durability_Consume2(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -417,9 +438,14 @@ func TestBroker_Durability_Consume2_2(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -506,9 +532,14 @@ func TestBroker_Durability_Consume3(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -576,9 +607,14 @@ func TestBroker_Durability_Consume4(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -606,23 +642,32 @@ func TestBroker_Durability_Consume4(t *testing.T) {
 
 	proxy.waitConn(2)
 
-	b.Push(pipe, &jobs.Job{
+	_, err = b.Push(pipe, &jobs.Job{
 		Job:     "test",
 		Payload: "kill",
 		Options: &jobs.Options{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Push(pipe, &jobs.Job{
+	_, err = b.Push(pipe, &jobs.Job{
 		Job:     "test",
 		Payload: "body",
 		Options: &jobs.Options{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Push(pipe, &jobs.Job{
+	_, err = b.Push(pipe, &jobs.Job{
 		Job:     "test",
 		Payload: "body",
 		Options: &jobs.Options{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	mu := sync.Mutex{}
 	done := make(map[string]bool)
@@ -654,8 +699,14 @@ func TestBroker_Durability_StopDead(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {

--- a/broker/amqp/queue.go
+++ b/broker/amqp/queue.go
@@ -106,13 +106,9 @@ func (q *queue) consume(consume *chanPool) (jobs <-chan amqp.Delivery, cc *chann
 
 	// do i like it?
 	go func(consume *chanPool) {
-		for {
-			select {
-			case err := <-cc.signal:
-				// channel error, we need new channel
-				consume.closeChan(cc, err)
-				return
-			}
+		for err := range cc.signal {
+			consume.closeChan(cc, err)
+			return
 		}
 	}(consume)
 

--- a/broker/amqp/stat_test.go
+++ b/broker/amqp/stat_test.go
@@ -8,7 +8,10 @@ import (
 
 func TestBroker_Stat(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})

--- a/broker/beanstalk/broker.go
+++ b/broker/beanstalk/broker.go
@@ -9,7 +9,6 @@ import (
 // Broker run consume using Broker service.
 type Broker struct {
 	cfg     *Config
-	mul     sync.Mutex
 	lsn     func(event int, ctx interface{})
 	mu      sync.Mutex
 	wait    chan error

--- a/broker/beanstalk/broker_test.go
+++ b/broker/beanstalk/broker_test.go
@@ -44,33 +44,48 @@ func init() {
 func TestBroker_Init(t *testing.T) {
 	b := &Broker{}
 	ok, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.True(t, ok)
 	assert.NoError(t, err)
 }
 
 func TestBroker_StopNotStarted(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	b.Stop()
 }
 
 func TestBroker_Register(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 }
 
 func TestBroker_Register_Twice(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 	assert.Error(t, b.Register(pipe))
 }
 
 func TestBroker_Register_Invalid(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Error(t, b.Register(&jobs.Pipeline{
 		"broker": "beanstalk",
 		"name":   "default",
@@ -79,35 +94,59 @@ func TestBroker_Register_Invalid(t *testing.T) {
 
 func TestBroker_Consume_Nil_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_Undefined(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	assert.NoError(t, b.Consume(pipe, exec, err))
+	assert.NoError(t, b.Consume(pipe, exec, errf))
 }
 
 func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Consume(pipe, nil, nil)
+	err = b.Consume(pipe, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -122,22 +161,34 @@ func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 
 func TestBroker_Consume_Serve_Error(t *testing.T) {
 	b := &Broker{}
-	b.Init(&Config{
+	_, err := b.Init(&Config{
 		Addr: "tcp://localhost:11399",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.Serve())
 }
 
 func TestBroker_Consume_Serve_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	b.Consume(pipe, exec, err)
+	err = b.Consume(pipe, exec, errf)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -152,25 +203,38 @@ func TestBroker_Consume_Serve_Stop(t *testing.T) {
 
 func TestBroker_PushToNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
-	_, err := b.Stat(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }
 
 func TestBroker_PushToNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -184,13 +248,16 @@ func TestBroker_PushToNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -204,6 +271,6 @@ func TestBroker_StatNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }

--- a/broker/beanstalk/consume_test.go
+++ b/broker/beanstalk/consume_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestBroker_Consume_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -50,7 +53,10 @@ func TestBroker_Consume_Job(t *testing.T) {
 
 func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -90,7 +96,10 @@ func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 
 func TestBroker_Consume_Delayed(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -135,7 +144,10 @@ func TestBroker_Consume_Delayed(t *testing.T) {
 
 func TestBroker_Consume_Errored(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})
@@ -178,7 +190,10 @@ func TestBroker_Consume_Errored(t *testing.T) {
 
 func TestBroker_Consume_Errored_Attempts(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})

--- a/broker/beanstalk/durability_test.go
+++ b/broker/beanstalk/durability_test.go
@@ -112,8 +112,14 @@ func TestBroker_Durability_Base(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -157,9 +163,14 @@ func TestBroker_Durability_Consume(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -223,9 +234,14 @@ func TestBroker_Durability_Consume_LongTimeout(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -303,9 +319,14 @@ func TestBroker_Durability_Consume2(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -379,9 +400,14 @@ func TestBroker_Durability_Consume3(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -438,9 +464,14 @@ func TestBroker_Durability_Consume4(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -458,23 +489,32 @@ func TestBroker_Durability_Consume4(t *testing.T) {
 
 	proxy.waitConn(2)
 
-	b.Push(pipe, &jobs.Job{
+	_, err = b.Push(pipe, &jobs.Job{
 		Job:     "test",
 		Payload: "kill",
 		Options: &jobs.Options{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Push(pipe, &jobs.Job{
+	_, err = b.Push(pipe, &jobs.Job{
 		Job:     "test",
 		Payload: "body",
 		Options: &jobs.Options{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Push(pipe, &jobs.Job{
+	_, err = b.Push(pipe, &jobs.Job{
 		Job:     "test",
 		Payload: "body",
 		Options: &jobs.Options{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	st, serr := b.Stat(pipe)
 	assert.NoError(t, serr)
@@ -507,9 +547,14 @@ func TestBroker_Durability_StopDead(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(pipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {

--- a/broker/beanstalk/stat_test.go
+++ b/broker/beanstalk/stat_test.go
@@ -9,7 +9,10 @@ import (
 
 func TestBroker_Stat(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+		_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	b.Register(pipe)
 
 	ready := make(chan interface{})

--- a/broker/ephemeral/broker_test.go
+++ b/broker/ephemeral/broker_test.go
@@ -23,7 +23,10 @@ func TestBroker_Init(t *testing.T) {
 
 func TestBroker_StopNotStarted(t *testing.T) {
 	b := &Broker{}
-	b.Init()
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	b.Stop()
 }
@@ -36,42 +39,69 @@ func TestBroker_Register(t *testing.T) {
 
 func TestBroker_Register_Twice(t *testing.T) {
 	b := &Broker{}
-	b.Init()
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 	assert.Error(t, b.Register(pipe))
 }
 
 func TestBroker_Consume_Nil_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_Undefined(t *testing.T) {
 	b := &Broker{}
-	b.Init()
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	assert.NoError(t, b.Consume(pipe, exec, err))
+	assert.NoError(t, b.Consume(pipe, exec, errf))
 }
 
 func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Consume(pipe, nil, nil)
+	err = b.Consume(pipe, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -86,13 +116,22 @@ func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 
 func TestBroker_Consume_Serve_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	b.Consume(pipe, exec, err)
+	err = b.Consume(pipe, exec, errf)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -107,25 +146,40 @@ func TestBroker_Consume_Serve_Stop(t *testing.T) {
 
 func TestBroker_PushToNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }
 
 func TestBroker_PushToNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init()
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -139,13 +193,16 @@ func TestBroker_PushToNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init()
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -159,6 +216,6 @@ func TestBroker_StatNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }

--- a/broker/ephemeral/consume_test.go
+++ b/broker/ephemeral/consume_test.go
@@ -10,8 +10,14 @@ import (
 
 func TestBroker_Consume_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -50,9 +56,14 @@ func TestBroker_Consume_Job(t *testing.T) {
 
 func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
-
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -90,9 +101,14 @@ func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 
 func TestBroker_Consume_Delayed(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
-
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -135,9 +151,14 @@ func TestBroker_Consume_Delayed(t *testing.T) {
 
 func TestBroker_Consume_Errored(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
-
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -178,9 +199,14 @@ func TestBroker_Consume_Errored(t *testing.T) {
 
 func TestBroker_Consume_Errored_Attempts(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
-
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {

--- a/broker/ephemeral/stat_test.go
+++ b/broker/ephemeral/stat_test.go
@@ -8,8 +8,14 @@ import (
 
 func TestBroker_Stat(t *testing.T) {
 	b := &Broker{}
-	b.Init()
-	b.Register(pipe)
+	_, err := b.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {

--- a/broker/sqs/broker_test.go
+++ b/broker/sqs/broker_test.go
@@ -28,26 +28,38 @@ var (
 func TestBroker_Init(t *testing.T) {
 	b := &Broker{}
 	ok, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.True(t, ok)
 	assert.NoError(t, err)
 }
 
 func TestBroker_StopNotStarted(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	b.Stop()
 }
 
 func TestBroker_Register(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 }
 
 func TestBroker_RegisterInvalid(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Error(t, b.Register(&jobs.Pipeline{
 		"broker": "sqs",
 		"name":   "default",
@@ -56,42 +68,69 @@ func TestBroker_RegisterInvalid(t *testing.T) {
 
 func TestBroker_Register_Twice(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Register(pipe))
 	assert.Error(t, b.Register(pipe))
 }
 
 func TestBroker_Consume_Nil_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NoError(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_Undefined(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.Consume(pipe, nil, nil))
 }
 
 func TestBroker_Consume_BeforeServe(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	assert.NoError(t, b.Consume(pipe, exec, err))
+	assert.NoError(t, b.Consume(pipe, exec, errf))
 }
 
 func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Consume(pipe, nil, nil)
+	err = b.Consume(pipe, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan interface{})
 	go func() {
@@ -106,13 +145,19 @@ func TestBroker_Consume_Serve_Nil_Stop(t *testing.T) {
 
 func TestBroker_Consume_Serve_Stop(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	b.Consume(pipe, exec, err)
+	b.Consume(pipe, exec, errf)
 
 	wait := make(chan interface{})
 	go func() {
@@ -136,38 +181,59 @@ func TestBroker_Consume_Serve_InvalidQueue(t *testing.T) {
 	}
 
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exec := make(chan jobs.Handler)
-	err := func(id string, j *jobs.Job, err error) {}
+	errf := func(id string, j *jobs.Job, err error) {}
 
-	b.Consume(pipe, exec, err)
+	b.Consume(pipe, exec, errf)
 
 	assert.Error(t, b.Serve())
 }
 
 func TestBroker_PushToNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRunning(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }
 
 func TestBroker_PushToNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -181,13 +247,16 @@ func TestBroker_PushToNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Push(pipe, &jobs.Job{})
+	_, err = b.Push(pipe, &jobs.Job{})
 	assert.Error(t, err)
 }
 
 func TestBroker_StatNotRegistered(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -201,6 +270,6 @@ func TestBroker_StatNotRegistered(t *testing.T) {
 
 	<-ready
 
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.Error(t, err)
 }

--- a/broker/sqs/consume_test.go
+++ b/broker/sqs/consume_test.go
@@ -10,8 +10,14 @@ import (
 
 func TestBroker_Consume_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -56,9 +62,14 @@ func TestBroker_Consume_JobUseExistedPipeline(t *testing.T) {
 	}
 
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -96,9 +107,14 @@ func TestBroker_Consume_JobUseExistedPipeline(t *testing.T) {
 
 func TestBroker_Consume_PushTooBigDelay(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -124,9 +140,14 @@ func TestBroker_Consume_PushTooBigDelay(t *testing.T) {
 
 func TestBroker_Consume_PushTooBigDelay2(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -152,9 +173,14 @@ func TestBroker_Consume_PushTooBigDelay2(t *testing.T) {
 
 func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -192,9 +218,14 @@ func TestBroker_ConsumeAfterStart_Job(t *testing.T) {
 
 func TestBroker_Consume_Delayed(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -237,9 +268,14 @@ func TestBroker_Consume_Delayed(t *testing.T) {
 
 func TestBroker_Consume_Errored(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -280,9 +316,14 @@ func TestBroker_Consume_Errored(t *testing.T) {
 
 func TestBroker_Consume_Errored_Attempts(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
-
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {

--- a/broker/sqs/durability_test.go
+++ b/broker/sqs/durability_test.go
@@ -125,8 +125,14 @@ func TestBroker_Durability_Base(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -170,9 +176,14 @@ func TestBroker_Durability_Consume(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -238,9 +249,14 @@ func TestBroker_Durability_Consume_LongTimeout(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -307,9 +323,14 @@ func TestBroker_Durability_Consume2(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -389,9 +410,14 @@ func TestBroker_Durability_Consume3(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -450,9 +476,14 @@ func TestBroker_Durability_Consume4(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {
@@ -470,23 +501,31 @@ func TestBroker_Durability_Consume4(t *testing.T) {
 
 	proxy.waitConn(1)
 
-	b.Push(proxyPipe, &jobs.Job{
+	_, err = b.Push(proxyPipe, &jobs.Job{
 		Job:     "test",
 		Payload: "kill",
 		Options: &jobs.Options{Timeout: 2},
 	})
-
-	b.Push(proxyPipe, &jobs.Job{
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.Push(proxyPipe, &jobs.Job{
 		Job:     "test",
 		Payload: "body",
 		Options: &jobs.Options{Timeout: 2},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	b.Push(proxyPipe, &jobs.Job{
+	_, err = b.Push(proxyPipe, &jobs.Job{
 		Job:     "test",
 		Payload: "body",
 		Options: &jobs.Options{Timeout: 2},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	st, serr := b.Stat(proxyPipe)
 	assert.NoError(t, serr)
@@ -521,9 +560,14 @@ func TestBroker_Durability_StopDead(t *testing.T) {
 	defer proxy.reset(true)
 
 	b := &Broker{}
-	b.Init(proxyCfg)
-	b.Register(proxyPipe)
-
+	_, err := b.Init(proxyCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(proxyPipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
 		if event == jobs.EventBrokerReady {

--- a/broker/sqs/stat_test.go
+++ b/broker/sqs/stat_test.go
@@ -8,8 +8,14 @@ import (
 
 func TestBroker_Stat(t *testing.T) {
 	b := &Broker{}
-	b.Init(cfg)
-	b.Register(pipe)
+	_, err := b.Init(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.Register(pipe)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ready := make(chan interface{})
 	b.Listen(func(event int, ctx interface{}) {
@@ -31,7 +37,7 @@ func TestBroker_Stat(t *testing.T) {
 	assert.NoError(t, perr)
 
 	// unable to use approximated stats
-	_, err := b.Stat(pipe)
+	_, err = b.Stat(pipe)
 	assert.NoError(t, err)
 
 	assert.NoError(t, b.Consume(pipe, exec, func(id string, j *jobs.Job, err error) {}))

--- a/broker_test.go
+++ b/broker_test.go
@@ -204,13 +204,14 @@ func newQueue() *testQueue {
 	return &testQueue{st: &Stat{}, jobs: make(chan *entry)}
 }
 
+// todo NOT USED
 // associate testQueue with new do pool
-func (q *testQueue) configure(execPool chan Handler, err ErrorHandler) error {
-	q.execPool = execPool
-	q.errHandler = err
-
-	return nil
-}
+//func (q *testQueue) configure(execPool chan Handler, err ErrorHandler) error {
+//	q.execPool = execPool
+//	q.errHandler = err
+//
+//	return nil
+//}
 
 // serve consumers
 func (q *testQueue) serve() {


### PR DESCRIPTION
1. Update non-breaking errors handling in tests
2. Update CI golangci-lint usage (skip errors handling check)
3. Simplify code, remove unused