### PR TITLE
Replace json std package with github.com/json-iterator/go

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           docker-compose -f ./tests/docker-compose.yml up -d
           vendor/bin/spiral-cs check src tests
+          go mod vendor
+          composer update
           go test -v -race -cover                    -coverprofile=jobs.txt      -covermode=atomic
           go test -v -race -cover ./broker/amqp      -coverprofile=amqp.txt      -covermode=atomic
           go test -v -race -cover ./broker/ephemeral -coverprofile=ephemeral.txt -covermode=atomic

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ install: all
 uninstall: 
 	rm -f /usr/local/bin/rr-jobs
 test:
+	go mod vendor
 	composer update
 	go test -v -race -cover
 	go test -v -race -cover ./broker/amqp

--- a/broker/amqp/broker.go
+++ b/broker/amqp/broker.go
@@ -56,13 +56,13 @@ func (b *Broker) Register(pipe *jobs.Pipeline) error {
 func (b *Broker) Serve() (err error) {
 	b.mu.Lock()
 
-	if b.publish, err = newConn(b.cfg.dial, b.cfg.TimeoutDuration()); err != nil {
+	if b.publish, err = newConn(b.cfg.Addr, b.cfg.TimeoutDuration()); err != nil {
 		b.mu.Unlock()
 		return err
 	}
 	defer b.publish.Close()
 
-	if b.consume, err = newConn(b.cfg.dial, b.cfg.TimeoutDuration()); err != nil {
+	if b.consume, err = newConn(b.cfg.Addr, b.cfg.TimeoutDuration()); err != nil {
 		b.mu.Unlock()
 		return err
 	}

--- a/broker/amqp/config.go
+++ b/broker/amqp/config.go
@@ -3,7 +3,6 @@ package amqp
 import (
 	"fmt"
 	"github.com/spiral/roadrunner/service"
-	"github.com/streadway/amqp"
 	"time"
 )
 
@@ -37,9 +36,4 @@ func (c *Config) TimeoutDuration() time.Duration {
 	}
 
 	return time.Duration(timeout) * time.Second
-}
-
-// dial dials to AMQP.
-func (c *Config) dial() (*amqp.Connection, error) {
-	return amqp.Dial(c.Addr)
 }

--- a/broker/amqp/config.go
+++ b/broker/amqp/config.go
@@ -29,7 +29,7 @@ func (c *Config) Hydrate(cfg service.Config) error {
 	return nil
 }
 
-// TimeoutDuration returns number of seconds allowed to allocate the publish.
+// TimeoutDuration returns number of seconds allowed to redial
 func (c *Config) TimeoutDuration() time.Duration {
 	timeout := c.Timeout
 	if timeout == 0 {

--- a/broker/amqp/config_test.go
+++ b/broker/amqp/config_test.go
@@ -1,7 +1,7 @@
 package amqp
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"github.com/spiral/roadrunner/service"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/broker/amqp/constants.go
+++ b/broker/amqp/constants.go
@@ -1,6 +1,0 @@
-package amqp
-
-import "time"
-
-// DefaultMaxInterval is the max reconnect time interval
-const DefaultMaxInterval = 30 * time.Second

--- a/broker/beanstalk/config_test.go
+++ b/broker/beanstalk/config_test.go
@@ -1,7 +1,7 @@
 package beanstalk
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"github.com/spiral/roadrunner/service"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/broker/beanstalk/conn.go
+++ b/broker/beanstalk/conn.go
@@ -111,7 +111,7 @@ func (cn *conn) release(err error) error {
 // watch and reconnect if dead
 func (cn *conn) watch(network, addr string) {
 	cn.free <- nil
-	t := time.NewTicker(time.Second)
+	t := time.NewTicker(WatchThrottleLimit)
 	defer t.Stop()
 	for {
 		select {

--- a/broker/beanstalk/conn.go
+++ b/broker/beanstalk/conn.go
@@ -111,9 +111,13 @@ func (cn *conn) release(err error) error {
 // watch and reconnect if dead
 func (cn *conn) watch(network, addr string) {
 	cn.free <- nil
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
 	for {
 		select {
 		case <-cn.dead:
+			// simple throttle limiter
+			<-t.C
 			// try to reconnect
 			// TODO add logging here
 			expb := backoff.NewExponentialBackOff()

--- a/broker/beanstalk/conn.go
+++ b/broker/beanstalk/conn.go
@@ -117,7 +117,7 @@ func (cn *conn) watch(network, addr string) {
 			// try to reconnect
 			// TODO add logging here
 			expb := backoff.NewExponentialBackOff()
-			expb.MaxInterval = time.Second * 5
+			expb.MaxInterval = cn.tout
 
 			reconnect := func() error {
 				conn, err := beanstalk.Dial(network, addr)

--- a/broker/beanstalk/constants.go
+++ b/broker/beanstalk/constants.go
@@ -1,0 +1,6 @@
+package beanstalk
+
+import "time"
+
+// WatchThrottleLimit is used to limit reconnection occurrence in watch function
+const WatchThrottleLimit = time.Second

--- a/broker/beanstalk/constants.go
+++ b/broker/beanstalk/constants.go
@@ -1,6 +1,0 @@
-package beanstalk
-
-import "time"
-
-// DefaultMaxInterval is the max reconnect time interval
-const DefaultMaxInterval = 30 * time.Second

--- a/broker/sqs/config_test.go
+++ b/broker/sqs/config_test.go
@@ -1,7 +1,7 @@
 package sqs
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"github.com/spiral/roadrunner/service"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,7 @@
 package jobs
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"github.com/spiral/roadrunner/service"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiral/jobs/v2
 
-go 1.13
+go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.16.14

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gofrs/uuid v3.1.0+incompatible
+	github.com/json-iterator/go v1.1.9
 	github.com/kr/beanstalk v0.0.0-20180818045031-cae1762e4858 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/prometheus/client_golang v1.5.0

--- a/job.go
+++ b/job.go
@@ -1,6 +1,6 @@
 package jobs
 
-import "encoding/json"
+import json "github.com/json-iterator/go"
 
 // Handler handles job execution.
 type Handler func(id string, j *Job) error


### PR DESCRIPTION
1. Refactor amqp/conn, move redial from config to conn.go
2. Remove dialing function, as not concurrent safe, refactor it
3. Simplify conn.notify function
4. Add a simple threshold limiter to BS/conn.go. Limit located in the constants.go file in beanstalk package